### PR TITLE
Update index.d.js for missing 'responseEncoding' property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,7 @@ export interface AxiosRequestConfig {
   adapter?: AxiosAdapter;
   auth?: AxiosBasicCredentials;
   responseType?: ResponseType;
+  responseEncoding?: BufferEncoding;
   xsrfCookieName?: string;
   xsrfHeaderName?: string;
   onUploadProgress?: (progressEvent: any) => void;


### PR DESCRIPTION
Update index.d.js for missing 'responseEncoding' property. In this way typescript don't warn an error.